### PR TITLE
changes in required php version in composer.json file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     }
   ],
   "require": {
-    "php": "^7.4|^8.0|^8.1"
+    "php": "^7.2|^7.3|^7.4|^8.0|^8.1"
   },
   "require-dev": {
     "orchestra/testbench": "^6.0",


### PR DESCRIPTION
added the required PHP version 7.2|7.3 in the composer.json file for integrating packages in lower versions.